### PR TITLE
Update README to recommend @import for Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,8 @@ gem 'us_web_design_standards'
 In your `app/assets/stylesheets/application.scss`, add the following:
 
 ```
-/*
- * = require us_web_design_standards
- * = require us_web_design_standards_fonts
- */
+@import "us_web_design_standards";
+@import "us_web_design_standards_fonts";
 ```
 
 In your `app/assets/javascripts/application.js`, add the following:


### PR DESCRIPTION
@harrisj 

As per `sass-rails`'s recommendation, we should use `@import` in Rails instead of `require`. This allows you to use all the variables in your Rails project.

See here: https://github.com/rails/sass-rails#important-note
