### PR TITLE
[ work in progress ] Deprecating this gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This `gem` has been deprecated.**
+
 # [`us_web_design_standards`](https://rubygems.org/gems/us_web_design_standards): U.S. Web Design Standards style assets gem
 
 Provides the style assets from the [U.S. Web Design


### PR DESCRIPTION
The Draft US Web Design Standards has been going through a major refactor. Because of this we will be deprecating this `gem` soon. This PR is currently a work in progress, and we will be creating a new workflow in the meantime with our new upcoming release `v0.9.0`. We are aware that this `gem` is being used by a number of projects.

**More information to come soon**.

> Please do not merge this Pull Request. It is mostly informational for the time being while we work on a migration plan for our [Standards website](http://playbook.cio.gov/designstandards/) which also [depends on this `gem`](https://github.com/18F/web-design-standards/blob/18f-pages-staging/Gemfile#L14-L18). Thanks! :trumpet: 
